### PR TITLE
Feat/cors headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ prost-wkt-types = "0.5.0"
 time = "0.3.30"
 digest = "0.10.7"
 reqsign = "0.14.3"
+serde_json = "1.0.108"
 
 [profile.release]
 panic = 'abort'

--- a/src/caching/auth.rs
+++ b/src/caching/auth.rs
@@ -13,6 +13,8 @@ use anyhow::bail;
 use anyhow::Result;
 use aruna_rust_api::api::storage::models::v2::DataClass;
 use diesel_ulid::DieselUlid;
+use http::HeaderMap;
+use http::HeaderValue;
 use http::Method;
 use jsonwebtoken::Algorithm;
 use jsonwebtoken::EncodingKey;
@@ -189,11 +191,23 @@ impl AuthHandler {
         creds: Option<&Credentials>,
         method: &Method,
         path: &S3Path,
+        headers: &HeaderMap<HeaderValue>,
     ) -> Result<CheckAccessResult> {
         let db_perm_from_method = DbPermissionLevel::from(method);
         trace!(extracted_perm = ?db_perm_from_method);
+
         if let Some(b) = path.as_bucket() {
             trace!("detected as_bucket");
+
+            let headers = if let Some((project, _)) = self
+                .cache
+                .get_full_resource_by_name(crate::structs::ResourceString::Project(b.to_string()))
+            {
+                project.project_get_headers(method, headers)?
+            } else {
+                None
+            };
+
             if method == Method::POST || method == Method::PUT {
                 trace!("detected POST/PUT");
                 let user = trace_err!(self
@@ -221,6 +235,7 @@ impl AuthHandler {
                     }),
                     object: None,
                     bundle: None,
+                    headers,
                 });
             } else {
                 trace!("detected not POST/PUT");
@@ -243,61 +258,125 @@ impl AuthHandler {
                     }),
                     None,
                     None,
+                    headers,
                 ));
             }
-        }
+        } else if let Some((bucket, _)) = path.as_object() {
+            let ((obj, loc), ids, missing, bundle) = self.extract_object_from_path(path, method)?;
+            if let Some(bundle) = bundle {
+                debug!(bundle, "bundle_detected");
 
-        let ((obj, loc), ids, missing, bundle) = self.extract_object_from_path(path, method)?;
-        if let Some(bundle) = bundle {
-            debug!(bundle, "bundle_detected");
-            if obj.object_type == ObjectType::Bundle {
-                // Check if user has access to Bundle Object
-                let user = trace_err!(self
-                    .cache
-                    .get_user_by_key(
-                        &trace_err!(creds.ok_or_else(|| anyhow!("Unknown user")))?.access_key
-                    )
-                    .ok_or_else(|| anyhow!("Unknown user")))?;
+                if obj.object_type == ObjectType::Bundle {
+                    // Check if user has access to Bundle Object
+                    let user = trace_err!(self
+                        .cache
+                        .get_user_by_key(
+                            &trace_err!(creds.ok_or_else(|| anyhow!("Unknown user")))?.access_key
+                        )
+                        .ok_or_else(|| anyhow!("Unknown user")))?;
 
-                for (res, perm) in user.permissions {
-                    // ResourceIds only contain Bundle Id as Project
-                    if ids.check_if_in(res) && perm >= db_perm_from_method {
-                        let token_id = if user.user_id.to_string() == user.access_key {
-                            None
-                        } else {
-                            Some(user.access_key.clone())
-                        };
+                    for (res, perm) in user.permissions {
+                        // ResourceIds only contain Bundle Id as Project
+                        if ids.check_if_in(res) && perm >= db_perm_from_method {
+                            let token_id = if user.user_id.to_string() == user.access_key {
+                                None
+                            } else {
+                                Some(user.access_key.clone())
+                            };
 
-                        return Ok(CheckAccessResult {
-                            user_id: Some(user.user_id.to_string()),
-                            token_id,
-                            resource_ids: None,
-                            missing_resources: None, // Bundles are standalone
-                            object: Some((obj, None)), // Bundles can't have a location
-                            bundle: Some(bundle),
-                        });
+                            return Ok(CheckAccessResult {
+                                user_id: Some(user.user_id.to_string()),
+                                token_id,
+                                resource_ids: None,
+                                missing_resources: None, // Bundles are standalone
+                                object: Some((obj, None)), // Bundles can't have a location
+                                bundle: Some(bundle),
+                                headers: None,
+                            });
+                        }
+                    }
+                }
+
+                if db_perm_from_method == DbPermissionLevel::Read
+                    && obj.data_class == DataClass::Public
+                {
+                    debug!("public_bundle");
+                    return Ok(CheckAccessResult {
+                        user_id: None,
+                        token_id: None,
+                        resource_ids: None,
+                        missing_resources: None,
+                        object: Some((obj, loc)),
+                        bundle: Some(bundle),
+                        headers: None,
+                    });
+                } else {
+                    debug!("bundle_not_public");
+                    let user = trace_err!(self
+                        .cache
+                        .get_user_by_key(
+                            &trace_err!(creds.ok_or_else(|| anyhow!("Unknown user")))?.access_key
+                        )
+                        .ok_or_else(|| anyhow!("Unknown user")))?;
+
+                    for (res, perm) in user.permissions {
+                        if ids.check_if_in(res) && perm >= db_perm_from_method {
+                            let token_id = if user.user_id.to_string() == user.access_key {
+                                None
+                            } else {
+                                Some(user.access_key.clone())
+                            };
+                            trace!(resource_id = ?res, permission = ?perm, "permission match found");
+                            return Ok(CheckAccessResult::new(
+                                Some(user.user_id.to_string()),
+                                token_id,
+                                Some(ids),
+                                missing,
+                                Some((obj, loc)),
+                                Some(bundle),
+                                None,
+                            ));
+                        }
                     }
                 }
             }
 
+            let headers = if let Some((project, _)) =
+                self.cache
+                    .get_full_resource_by_name(crate::structs::ResourceString::Project(
+                        bucket.to_string(),
+                    )) {
+                project.project_get_headers(method, headers)?
+            } else {
+                None
+            };
+
+            match method {
+                &Method::GET | &Method::HEAD | &Method::OPTIONS | &Method::DELETE => {
+                    if missing.is_some() {
+                        bail!("Resource not found")
+                    }
+                }
+                _ => {}
+            };
+
             if db_perm_from_method == DbPermissionLevel::Read && obj.data_class == DataClass::Public
             {
-                debug!("public_bundle");
-                return Ok(CheckAccessResult {
-                    user_id: None,
-                    token_id: None,
-                    resource_ids: None,
-                    missing_resources: None,
-                    object: Some((obj, loc)),
-                    bundle: Some(bundle),
-                });
-            } else {
-                debug!("bundle_not_public");
+                debug!("public_object");
+                return Ok(CheckAccessResult::new(
+                    None,
+                    None,
+                    Some(ids),
+                    missing,
+                    Some((obj, loc)),
+                    None,
+                    headers,
+                ));
+            } else if let Some(creds) = creds {
+                debug!("private object");
                 let user = trace_err!(self
                     .cache
-                    .get_user_by_key(
-                        &trace_err!(creds.ok_or_else(|| anyhow!("Unknown user")))?.access_key
-                    )
+                    .get_user_by_key(&creds.access_key)
                     .ok_or_else(|| anyhow!("Unknown user")))?;
 
                 for (res, perm) in user.permissions {
@@ -314,55 +393,10 @@ impl AuthHandler {
                             Some(ids),
                             missing,
                             Some((obj, loc)),
-                            Some(bundle),
+                            None,
+                            headers,
                         ));
                     }
-                }
-            }
-        }
-
-        match method {
-            &Method::GET | &Method::HEAD | &Method::OPTIONS | &Method::DELETE => {
-                if missing.is_some() {
-                    bail!("Resource not found")
-                }
-            }
-            _ => {}
-        };
-
-        if db_perm_from_method == DbPermissionLevel::Read && obj.data_class == DataClass::Public {
-            debug!("public_object");
-            return Ok(CheckAccessResult::new(
-                None,
-                None,
-                Some(ids),
-                missing,
-                Some((obj, loc)),
-                None,
-            ));
-        } else if let Some(creds) = creds {
-            debug!("private object");
-            let user = trace_err!(self
-                .cache
-                .get_user_by_key(&creds.access_key)
-                .ok_or_else(|| anyhow!("Unknown user")))?;
-
-            for (res, perm) in user.permissions {
-                if ids.check_if_in(res) && perm >= db_perm_from_method {
-                    let token_id = if user.user_id.to_string() == user.access_key {
-                        None
-                    } else {
-                        Some(user.access_key.clone())
-                    };
-                    trace!(resource_id = ?res, permission = ?perm, "permission match found");
-                    return Ok(CheckAccessResult::new(
-                        Some(user.user_id.to_string()),
-                        token_id,
-                        Some(ids),
-                        missing,
-                        Some((obj, loc)),
-                        None,
-                    ));
                 }
             }
         }

--- a/src/caching/auth.rs
+++ b/src/caching/auth.rs
@@ -203,7 +203,7 @@ impl AuthHandler {
                 .cache
                 .get_full_resource_by_name(crate::structs::ResourceString::Project(b.to_string()))
             {
-                project.project_get_headers(method, headers)?
+                project.project_get_headers(method, headers)
             } else {
                 None
             };
@@ -346,7 +346,7 @@ impl AuthHandler {
                     .get_full_resource_by_name(crate::structs::ResourceString::Project(
                         bucket.to_string(),
                     )) {
-                project.project_get_headers(method, headers)?
+                project.project_get_headers(method, headers)
             } else {
                 None
             };

--- a/src/caching/auth.rs
+++ b/src/caching/auth.rs
@@ -223,6 +223,24 @@ impl AuthHandler {
                     Some(user.access_key.clone())
                 };
 
+                let bucket_obj = self.cache.get_full_resource_by_name(crate::structs::ResourceString::Project(b.to_string()));
+
+                if let Some((ref project, _)) = bucket_obj {
+                    if let Some(perm) = user.permissions.get(&project.id) {
+                        if *perm >= DbPermissionLevel::Write {
+                            return Ok(CheckAccessResult {
+                                user_id: Some(user.user_id.to_string()),
+                                token_id: Some(user.access_key.clone()),
+                                resource_ids: Some(ResourceIds::Project(project.id)),
+                                missing_resources: None,
+                                object: bucket_obj,
+                                bundle: None,
+                                headers,
+                            });
+                        }
+                    }
+                }
+
                 return Ok(CheckAccessResult {
                     user_id: Some(user.user_id.to_string()),
                     token_id,
@@ -245,6 +263,25 @@ impl AuthHandler {
                         &trace_err!(creds.ok_or_else(|| anyhow!("Unknown user")))?.access_key
                     )
                     .ok_or_else(|| anyhow!("Unknown user")))?;
+
+                let bucket_obj = self.cache.get_full_resource_by_name(crate::structs::ResourceString::Project(b.to_string()));
+
+                if let Some((ref project, _)) = bucket_obj {
+                    if let Some(perm) = user.permissions.get(&project.id) {
+                        if *perm >= DbPermissionLevel::Read {
+                            return Ok(CheckAccessResult {
+                                user_id: Some(user.user_id.to_string()),
+                                token_id: Some(user.access_key.clone()),
+                                resource_ids: Some(ResourceIds::Project(project.id)),
+                                missing_resources: None,
+                                object: bucket_obj,
+                                bundle: None,
+                                headers,
+                            });
+                        }
+                    }
+                }
+
 
                 return Ok(CheckAccessResult::new(
                     Some(user.user_id.to_string()),

--- a/src/caching/auth.rs
+++ b/src/caching/auth.rs
@@ -230,7 +230,7 @@ impl AuthHandler {
                         if *perm >= DbPermissionLevel::Write {
                             return Ok(CheckAccessResult {
                                 user_id: Some(user.user_id.to_string()),
-                                token_id: Some(user.access_key.clone()),
+                                token_id: token_id.clone(),
                                 resource_ids: Some(ResourceIds::Project(project.id)),
                                 missing_resources: None,
                                 object: bucket_obj,
@@ -320,6 +320,8 @@ impl AuthHandler {
                             } else {
                                 Some(user.access_key.clone())
                             };
+
+                            trace!(resource_id = ?res, permission = ?perm, user_id = ?user.user_id, key = ?user.access_key, "permission match found");
 
                             return Ok(CheckAccessResult {
                                 user_id: Some(user.user_id.to_string()),

--- a/src/caching/auth.rs
+++ b/src/caching/auth.rs
@@ -223,7 +223,11 @@ impl AuthHandler {
                     Some(user.access_key.clone())
                 };
 
-                let bucket_obj = self.cache.get_full_resource_by_name(crate::structs::ResourceString::Project(b.to_string()));
+                let bucket_obj =
+                    self.cache
+                        .get_full_resource_by_name(crate::structs::ResourceString::Project(
+                            b.to_string(),
+                        ));
 
                 if let Some((ref project, _)) = bucket_obj {
                     if let Some(perm) = user.permissions.get(&project.id) {
@@ -264,7 +268,11 @@ impl AuthHandler {
                     )
                     .ok_or_else(|| anyhow!("Unknown user")))?;
 
-                let bucket_obj = self.cache.get_full_resource_by_name(crate::structs::ResourceString::Project(b.to_string()));
+                let bucket_obj =
+                    self.cache
+                        .get_full_resource_by_name(crate::structs::ResourceString::Project(
+                            b.to_string(),
+                        ));
 
                 if let Some((ref project, _)) = bucket_obj {
                     if let Some(perm) = user.permissions.get(&project.id) {
@@ -281,7 +289,6 @@ impl AuthHandler {
                         }
                     }
                 }
-
 
                 return Ok(CheckAccessResult::new(
                     Some(user.user_id.to_string()),

--- a/src/caching/cache.rs
+++ b/src/caching/cache.rs
@@ -277,6 +277,20 @@ impl Cache {
         trace!("updated pks in cache");
         Ok(())
     }
+    #[tracing::instrument(level = "trace", skip(self, res))]
+    pub fn get_full_resource_by_name(
+        &self,
+        res: ResourceString,
+    ) -> Option<(Object, Option<ObjectLocation>)> {
+        self.paths
+            .get(&res)
+            .map(|e| {
+                let id = e.value().clone();
+                self.resources.get(&id.get_id()).map(|e| e.value().clone())
+            })
+            .flatten()
+            .clone()
+    }
 
     #[tracing::instrument(level = "trace", skip(self, res))]
     pub fn get_res_by_res_string(&self, res: ResourceString) -> Option<ResourceIds> {

--- a/src/caching/cache.rs
+++ b/src/caching/cache.rs
@@ -284,11 +284,10 @@ impl Cache {
     ) -> Option<(Object, Option<ObjectLocation>)> {
         self.paths
             .get(&res)
-            .map(|e| {
+            .and_then(|e| {
                 let id = e.value().clone();
                 self.resources.get(&id.get_id()).map(|e| e.value().clone())
             })
-            .flatten()
             .clone()
     }
 

--- a/src/caching/grpc_query_handler.rs
+++ b/src/caching/grpc_query_handler.rs
@@ -398,12 +398,15 @@ impl GrpcQueryHandler {
 
         let mut req = Request::new(UpdateProjectKeyValuesRequest {
             project_id: obj.id.to_string(),
-            add_key_values: kv.map(|(k,v)| {
-                vec![KeyValue {
-                key: k.to_string(),
-                value: v.to_string(),
-                variant: KeyValueVariant::Label as i32,
-            }]}).unwrap_or_default(),
+            add_key_values: kv
+                .map(|(k, v)| {
+                    vec![KeyValue {
+                        key: k.to_string(),
+                        value: v.to_string(),
+                        variant: KeyValueVariant::Label as i32,
+                    }]
+                })
+                .unwrap_or_default(),
             remove_key_values: remove_cors,
         });
 

--- a/src/caching/grpc_query_handler.rs
+++ b/src/caching/grpc_query_handler.rs
@@ -15,13 +15,13 @@ use aruna_rust_api::api::notification::services::v2::GetEventMessageStreamReques
 use aruna_rust_api::api::notification::services::v2::Reply;
 use aruna_rust_api::api::notification::services::v2::ResourceEvent;
 use aruna_rust_api::api::notification::services::v2::UserEvent;
-use aruna_rust_api::api::storage::models::v2::KeyValue;
-use aruna_rust_api::api::storage::models::v2::KeyValueVariant;
 use aruna_rust_api::api::storage::models::v2::generic_resource::Resource;
 use aruna_rust_api::api::storage::models::v2::Collection;
 use aruna_rust_api::api::storage::models::v2::Dataset;
 use aruna_rust_api::api::storage::models::v2::GenericResource;
 use aruna_rust_api::api::storage::models::v2::Hash;
+use aruna_rust_api::api::storage::models::v2::KeyValue;
+use aruna_rust_api::api::storage::models::v2::KeyValueVariant;
 use aruna_rust_api::api::storage::models::v2::Object;
 use aruna_rust_api::api::storage::models::v2::Project;
 use aruna_rust_api::api::storage::models::v2::Pubkey;
@@ -412,7 +412,12 @@ impl GrpcQueryHandler {
             trace_err!(AsciiMetadataValue::try_from(format!("Bearer {}", token)))?,
         );
 
-        trace_err!(self.project_service.clone().update_project_key_values(req).await)?;
+        trace_err!(
+            self.project_service
+                .clone()
+                .update_project_key_values(req)
+                .await
+        )?;
         Ok(())
     }
 

--- a/src/caching/grpc_query_handler.rs
+++ b/src/caching/grpc_query_handler.rs
@@ -387,8 +387,7 @@ impl GrpcQueryHandler {
         &self,
         token: &str,
         obj: DPObject,
-        key: &str,
-        value: &str,
+        kv: Option<(&str, &str)>,
     ) -> Result<()> {
         let remove_cors = obj
             .key_values
@@ -399,11 +398,12 @@ impl GrpcQueryHandler {
 
         let mut req = Request::new(UpdateProjectKeyValuesRequest {
             project_id: obj.id.to_string(),
-            add_key_values: vec![KeyValue {
-                key: key.to_string(),
-                value: value.to_string(),
+            add_key_values: kv.map(|(k,v)| {
+                vec![KeyValue {
+                key: k.to_string(),
+                value: v.to_string(),
                 variant: KeyValueVariant::Label as i32,
-            }],
+            }]}).unwrap_or_default(),
             remove_key_values: remove_cors,
         });
 

--- a/src/s3_frontend/auth.rs
+++ b/src/s3_frontend/auth.rs
@@ -34,7 +34,7 @@ impl S3Auth for AuthProvider {
         match self.cache.auth.read().await.as_ref() {
             Some(auth) => {
                 let result = trace_err!(
-                    auth.check_access(cx.credentials(), cx.method(), cx.s3_path())
+                    auth.check_access(cx.credentials(), cx.method(), cx.s3_path(), cx.headers())
                         .await
                 )
                 .map_err(|err| {

--- a/src/s3_frontend/s3service.rs
+++ b/src/s3_frontend/s3service.rs
@@ -137,8 +137,7 @@ impl S3 for ArunaS3Service {
                     .input
                     .body
                     .as_ref()
-                    .map(|b| b.remaining_length().exact())
-                    .flatten()
+                    .and_then(|b| b.remaining_length().exact())
                 {
                     Some(0) | None => {
                         error!("Missing or invalid (0) content-length");
@@ -792,8 +791,7 @@ impl S3 for ArunaS3Service {
                     .input
                     .body
                     .as_ref()
-                    .map(|b| b.remaining_length().exact())
-                    .flatten()
+                    .and_then(|b| b.remaining_length().exact())
                 {
                     Some(0) | None => {
                         error!("Missing or invalid (0) content-length");

--- a/src/s3_frontend/s3service.rs
+++ b/src/s3_frontend/s3service.rs
@@ -97,7 +97,7 @@ impl S3 for ArunaS3Service {
             let CheckAccessResult {
                 user_id, token_id, ..
             } = trace_err!(data.ok_or_else(|| s3_error!(InternalError, "Internal Error")))?;
-
+            trace!(?user_id, ?token_id, "impersonating user");
             let token = trace_err!(self
                 .cache
                 .auth
@@ -166,6 +166,7 @@ impl S3 for ArunaS3Service {
             .cloned()
             .ok_or_else(|| s3_error!(UnexpectedContent, "Missing data context")))?;
 
+        trace!(?user_id, ?token_id, "impersonating user");
         let impersonating_token = if let Some(auth_handler) = self.cache.auth.read().await.as_ref()
         {
             user_id.and_then(|u| auth_handler.sign_impersonating_token(u, token_id).ok())
@@ -1491,6 +1492,8 @@ impl S3 for ArunaS3Service {
                 object,
                 ..
             } = trace_err!(data.ok_or_else(|| s3_error!(InternalError, "Internal Error")))?;
+
+            trace!(?token_id, ?user_id, "put_bucket_cors");
 
             let (bucket_obj, _) =
                 object.ok_or_else(|| s3_error!(NoSuchBucket, "Bucket not found"))?;

--- a/src/s3_frontend/s3service.rs
+++ b/src/s3_frontend/s3service.rs
@@ -1311,6 +1311,8 @@ impl S3 for ArunaS3Service {
 
         debug!(?output);
 
+        debug!(?headers);
+
         let mut resp = S3Response::new(output);
         if let Some(headers) = headers {
             for (k, v) in headers {

--- a/src/s3_frontend/s3service.rs
+++ b/src/s3_frontend/s3service.rs
@@ -138,8 +138,7 @@ impl S3 for ArunaS3Service {
                     .input
                     .body
                     .as_ref()
-                    .map(|b| b.remaining_length().exact())
-                    .flatten()
+                    .and_then(|b| b.remaining_length().exact())
                 {
                     Some(0) | None => {
                         error!("Missing or invalid (0) content-length");
@@ -799,8 +798,7 @@ impl S3 for ArunaS3Service {
                     .input
                     .body
                     .as_ref()
-                    .map(|b| b.remaining_length().exact())
-                    .flatten()
+                    .and_then(|b| b.remaining_length().exact())
                 {
                     Some(0) | None => {
                         error!("Missing or invalid (0) content-length");
@@ -1249,7 +1247,7 @@ impl S3 for ArunaS3Service {
                 resp.headers.insert(
                     HeaderName::from_bytes(k.as_bytes())
                         .map_err(|_| s3_error!(InternalError, "Unable to parse header name"))?,
-                    HeaderValue::from_str(&*v)
+                    HeaderValue::from_str(&v)
                         .map_err(|_| s3_error!(InternalError, "Unable to parse header value"))?,
                 );
             }
@@ -1326,7 +1324,7 @@ impl S3 for ArunaS3Service {
                 resp.headers.insert(
                     HeaderName::from_bytes(k.as_bytes())
                         .map_err(|_| s3_error!(InternalError, "Unable to parse header name"))?,
-                    HeaderValue::from_str(&*v)
+                    HeaderValue::from_str(&v)
                         .map_err(|_| s3_error!(InternalError, "Unable to parse header value"))?,
                 );
             }
@@ -1469,7 +1467,7 @@ impl S3 for ArunaS3Service {
                 resp.headers.insert(
                     HeaderName::from_bytes(k.as_bytes())
                         .map_err(|_| s3_error!(InternalError, "Unable to parse header name"))?,
-                    HeaderValue::from_str(&*v)
+                    HeaderValue::from_str(&v)
                         .map_err(|_| s3_error!(InternalError, "Unable to parse header value"))?,
                 );
             }
@@ -1606,8 +1604,7 @@ impl S3 for ArunaS3Service {
         let CheckAccessResult { object, .. } =
             trace_err!(data.ok_or_else(|| s3_error!(InternalError, "Internal Error")))?;
 
-        let (bucket_obj, _) =
-            object.ok_or_else(|| s3_error!(NoSuchBucket, "Bucket not found"))?;
+        let (bucket_obj, _) = object.ok_or_else(|| s3_error!(NoSuchBucket, "Bucket not found"))?;
 
         let cors = bucket_obj
             .key_values

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -56,7 +56,7 @@ impl From<&Method> for DbPermissionLevel {
     #[tracing::instrument(level = "trace", skip(method))]
     fn from(method: &Method) -> Self {
         match *method {
-            Method::GET | Method::OPTIONS => DbPermissionLevel::Read,
+            Method::GET | Method::OPTIONS | Method::HEAD => DbPermissionLevel::Read,
             Method::POST | Method::PUT => DbPermissionLevel::Append,
             Method::DELETE => DbPermissionLevel::Write,
             _ => DbPermissionLevel::Admin,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1571,20 +1571,20 @@ impl CORSConfiguration {
                 if !cors_rule.allowed_origins.is_empty() {
                     headers.insert(
                         "Access-Control-Allow-Origin".to_string(),
-                        cors_rule.allowed_origins.join(","),
+                        cors_rule.allowed_origins.join(", "),
                     );
                 }
                 if !cors_rule.allowed_methods.is_empty() {
                     headers.insert(
                         "Access-Control-Allow-Methods".to_string(),
-                        cors_rule.allowed_methods.join(","),
+                        cors_rule.allowed_methods.join(", "),
                     );
                 }
                 if let Some(head) = cors_rule.allowed_headers {
-                    headers.insert("Access-Control-Allow-Headers".to_string(), head.join(","));
+                    headers.insert("Access-Control-Allow-Headers".to_string(), head.join(", "));
                 }
                 if let Some(head) = cors_rule.expose_headers {
-                    headers.insert("Access-Control-Expose-Headers".to_string(), head.join(","));
+                    headers.insert("Access-Control-Expose-Headers".to_string(), head.join(", "));
                 }
 
                 if cors_rule.max_age_seconds == 0 {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -23,8 +23,8 @@ use aruna_rust_api::api::storage::services::v2::UpdateObjectRequest;
 use chrono::NaiveDateTime;
 use diesel_ulid::DieselUlid;
 use http::{HeaderValue, Method};
-use s3s::dto::{CORSRule as S3SCORSRule, GetBucketCorsOutput};
 use s3s::dto::CreateBucketInput;
+use s3s::dto::{CORSRule as S3SCORSRule, GetBucketCorsOutput};
 use s3s::path::S3Path;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -32,7 +32,7 @@ use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
 };
-use tracing::{error, trace, debug};
+use tracing::{debug, error};
 
 /* ----- Constants ----- */
 pub const ALL_RIGHTS_RESERVED: &str = "AllRightsReserved";
@@ -1518,15 +1518,15 @@ impl From<S3SCORSRule> for CORSRule {
     }
 }
 
-impl Into<S3SCORSRule> for CORSRule {
-    fn into(self) -> S3SCORSRule {
+impl From<CORSRule> for S3SCORSRule {
+    fn from(val: CORSRule) -> Self {
         S3SCORSRule {
-            id: self.id,
-            allowed_headers: self.allowed_headers,
-            allowed_methods: self.allowed_methods,
-            allowed_origins: self.allowed_origins,
-            expose_headers: self.expose_headers,
-            max_age_seconds: self.max_age_seconds,
+            id: val.id,
+            allowed_headers: val.allowed_headers,
+            allowed_methods: val.allowed_methods,
+            allowed_origins: val.allowed_origins,
+            expose_headers: val.expose_headers,
+            max_age_seconds: val.max_age_seconds,
         }
     }
 }
@@ -1534,9 +1534,13 @@ impl Into<S3SCORSRule> for CORSRule {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CORSConfiguration(pub Vec<CORSRule>);
 
-impl Into<GetBucketCorsOutput> for CORSConfiguration {
-    fn into(self) -> GetBucketCorsOutput {
-        let cors_rule = self.0.iter().map(|x| CORSRule::into(x.clone())).collect::<Vec<S3SCORSRule>>();
+impl From<CORSConfiguration> for GetBucketCorsOutput {
+    fn from(val: CORSConfiguration) -> Self {
+        let cors_rule = val
+            .0
+            .iter()
+            .map(|x| CORSRule::into(x.clone()))
+            .collect::<Vec<S3SCORSRule>>();
         if cors_rule.is_empty() {
             GetBucketCorsOutput {
                 cors_rules: None,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -23,6 +23,7 @@ use aruna_rust_api::api::storage::services::v2::UpdateObjectRequest;
 use chrono::NaiveDateTime;
 use diesel_ulid::DieselUlid;
 use http::Method;
+use s3s::dto::CORSRule as S3SCORSRule;
 use s3s::dto::CreateBucketInput;
 use s3s::path::S3Path;
 use serde::{Deserialize, Serialize};
@@ -1438,6 +1439,30 @@ impl CheckAccessResult {
         }
     }
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CORSRule {
+    pub allowed_headers: Vec<String>,
+    pub allowed_methods: Vec<String>,
+    pub allowed_origins: Vec<String>,
+    pub expose_headers: Vec<String>,
+    pub max_age_seconds: i32,
+}
+
+impl From<S3SCORSRule> for CORSRule {
+    fn from(value: S3SCORSRule) -> Self {
+        Self {
+            allowed_headers: value.allowed_headers.unwrap_or_default(),
+            allowed_methods: value.allowed_methods,
+            allowed_origins: value.allowed_origins,
+            expose_headers: value.expose_headers.unwrap_or_default(),
+            max_age_seconds: value.max_age_seconds,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CORSConfiguration(pub Vec<CORSRule>);
 
 #[cfg(test)]
 mod tests {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -32,7 +32,7 @@ use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
 };
-use tracing::error;
+use tracing::{error, trace, debug};
 
 /* ----- Constants ----- */
 pub const ALL_RIGHTS_RESERVED: &str = "AllRightsReserved";
@@ -820,7 +820,7 @@ impl Object {
             .key_values
             .iter()
             .find_map(|e| {
-                if e.key == "apps.aruna-storage.org/cors" {
+                if e.key == "app.aruna-storage.org/cors" {
                     match serde_json::from_str::<CORSConfiguration>(&e.value) {
                         Ok(config) => Some(config.into_headers(
                             request_origin.to_string(),
@@ -833,6 +833,7 @@ impl Object {
                         }
                     }
                 } else {
+                    debug!("No cors config");
                     None
                 }
             })
@@ -1551,6 +1552,7 @@ impl Into<GetBucketCorsOutput> for CORSConfiguration {
 }
 
 impl CORSConfiguration {
+    #[tracing::instrument]
     pub fn into_headers(
         self,
         origin: String,
@@ -1594,10 +1596,7 @@ impl CORSConfiguration {
                             return None;
                         }
                     }
-                } else {
-                    return None;
                 }
-
                 return Some(headers);
             }
         }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -798,17 +798,16 @@ impl Object {
         &self,
         request_method: &http::Method,
         header: &http::HeaderMap<HeaderValue>,
-    ) -> Result<Option<HashMap<String, String>>> {
+    ) -> Option<HashMap<String, String>> {
         if self.object_type != ObjectType::Project {
             error!("Invalid object type");
-            return Err(anyhow!("Invalid object type"));
+            return None;
         }
 
         let request_origin = header
-            .get(hyper::header::ORIGIN)
-            .ok_or_else(|| anyhow!("Missing origin header"))?
+            .get(hyper::header::ORIGIN)?
             .to_str()
-            .map_err(|_| anyhow!("Invalid origin header"))?;
+            .ok()?;
 
         let request_headers = header
             .get(hyper::header::ACCESS_CONTROL_REQUEST_HEADERS)
@@ -842,7 +841,7 @@ impl Object {
             })
             .flatten();
 
-        Ok(key)
+        key
     }
 }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -815,7 +815,7 @@ impl Object {
             .map(|x| {
                 x.to_str()
                     .unwrap_or("")
-                    .split(",")
+                    .split(',')
                     .map(|e| e.trim().to_string())
                     .collect::<Vec<String>>()
             });
@@ -833,7 +833,7 @@ impl Object {
                         )),
                         _ => {
                             error!("Invalid cors config");
-                            return None;
+                            None
                         }
                     }
                 } else {
@@ -1527,52 +1527,50 @@ impl CORSConfiguration {
         header: Option<Vec<String>>,
     ) -> Option<HashMap<String, String>> {
         for cors_rule in self.0 {
-            if cors_rule.allowed_origins.contains(&origin) {
-                if cors_rule.allowed_methods.contains(&method) {
-                    let mut headers = HashMap::new();
-                    if !cors_rule.allowed_origins.is_empty() {
-                        headers.insert(
-                            "Access-Control-Allow-Origin".to_string(),
-                            cors_rule.allowed_origins.join(","),
-                        );
-                    }
-                    if !cors_rule.allowed_methods.is_empty() {
-                        headers.insert(
-                            "Access-Control-Allow-Methods".to_string(),
-                            cors_rule.allowed_methods.join(","),
-                        );
-                    }
-                    if !cors_rule.allowed_headers.is_empty() {
-                        headers.insert(
-                            "Access-Control-Allow-Headers".to_string(),
-                            cors_rule.allowed_headers.join(","),
-                        );
-                    }
-                    if !cors_rule.expose_headers.is_empty() {
-                        headers.insert(
-                            "Access-Control-Expose-Headers".to_string(),
-                            cors_rule.expose_headers.join(","),
-                        );
-                    }
-                    if cors_rule.max_age_seconds == 0 {
-                        headers.insert(
-                            "Access-Control-Max-Age".to_string(),
-                            cors_rule.max_age_seconds.to_string(),
-                        );
-                    }
-
-                    if let Some(expected_headers) = header {
-                        for header in expected_headers {
-                            if !headers.contains_key(&header) {
-                                return None;
-                            }
-                        }
-                    } else {
-                        return None;
-                    }
-
-                    return Some(headers);
+            if cors_rule.allowed_origins.contains(&origin) && cors_rule.allowed_methods.contains(&method) {
+                let mut headers = HashMap::new();
+                if !cors_rule.allowed_origins.is_empty() {
+                    headers.insert(
+                        "Access-Control-Allow-Origin".to_string(),
+                        cors_rule.allowed_origins.join(","),
+                    );
                 }
+                if !cors_rule.allowed_methods.is_empty() {
+                    headers.insert(
+                        "Access-Control-Allow-Methods".to_string(),
+                        cors_rule.allowed_methods.join(","),
+                    );
+                }
+                if !cors_rule.allowed_headers.is_empty() {
+                    headers.insert(
+                        "Access-Control-Allow-Headers".to_string(),
+                        cors_rule.allowed_headers.join(","),
+                    );
+                }
+                if !cors_rule.expose_headers.is_empty() {
+                    headers.insert(
+                        "Access-Control-Expose-Headers".to_string(),
+                        cors_rule.expose_headers.join(","),
+                    );
+                }
+                if cors_rule.max_age_seconds == 0 {
+                    headers.insert(
+                        "Access-Control-Max-Age".to_string(),
+                        cors_rule.max_age_seconds.to_string(),
+                    );
+                }
+
+                if let Some(expected_headers) = header {
+                    for header in expected_headers {
+                        if !headers.contains_key(&header) {
+                            return None;
+                        }
+                    }
+                } else {
+                    return None;
+                }
+
+                return Some(headers);
             }
         }
         None


### PR DESCRIPTION
## CORS handling

PR implementing all necessary parts for handling CORS requests with S3.

CORS configuration can be added in two ways: 

1. Via the PutBucketCORS S3 request (preferred)
2. By adding a Label with a manual cors configuration:

Example:
```json
{
  "key": "app.aruna-storage.org/cors",
  "value": [
    {
      "id": "cors",
      "allowed_headers": [
        "*"
      ],
      "allowed_methods": [
        "GET",
        "HEAD"
      ],
      "allowed_origins": [
        "https://www.example.com"
      ],
      "max_age_seconds": 86400
    }
  ]
}
```

## Changes

- Added PutBucketCors
- Added DeleteBucketCors
- Added GetBucketCors
- Added blanket impl for GetBucketLocation (This will always return us-east1)
- Add CORS config as `app.aruna-storage.org/cors` label to project

### Fixes

- Fix HEAD object public permissions
- Fix Bucket modification (PUT/POST) permission check

resolves #29